### PR TITLE
Add flag to specify custom configuration file

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,5 +85,5 @@ Multiple Configurations
 You may want to have multiple configuration files within the same project, in order to allow different proxying rules depending on the envirnoment you are working on (e.g. local vs QA). You can specify a custom config file by using the `--config` flag as follows:
 
 ```bash
-sudo vee --config .vee.qa
+vee --config .vee.qa
 ```

--- a/README.md
+++ b/README.md
@@ -78,3 +78,12 @@ default:
 contacts-ui:
   port: 8888
 ```
+
+Multiple Configurations
+-----------------------
+
+You may want to have multiple configuration files within the same project, in order to allow different proxying rules depending on the envirnoment you are working on (e.g. local vs QA). You can specify a custom config file by using the `--config` flag as follows:
+
+```bash
+sudo vee --config .vee.qa
+```

--- a/app.coffee
+++ b/app.coffee
@@ -20,6 +20,7 @@ commander
   .option('-s, --https-port [443]', "Port to serve https requests from (0 to disable).", NumberList)
   .option('-d, --debug', "Output route matching debug info.", Boolean)
   .option('-r, --pass-redirects', "Pass 3XXs to the browser, rather than following them.", Boolean)
+  .option('-c, --config <config>', 'Specify a configuration file. Defaults to ./.vee', '.vee')
   .parse(process.argv)
 
 watcher = null
@@ -40,7 +41,7 @@ waitForFileToExist = (file, callback) ->
       else if +(new Date) - start < waitTime
         setImmediate checkFile
       else
-        console.error ".vee configuration file not found within #{waitTime}ms".red
+        console.error "configuration file not found within #{waitTime}ms".red
         process.exit(1)
 
 loadCfg = (file) ->
@@ -63,10 +64,10 @@ start = ->
   # - Command line flags
 
   try
-    project = loadCfg '.vee'
+    project = loadCfg commander.config
   catch e
     if e.code is 'ENOENT'
-      console.error ".vee configuration file not found in the current directory".red
+      console.error "configuration file not found in the current directory".red
       process.exit(1)
     else
       throw e

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vee",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Proxy to make local development of static apps easy",
   "main": "start.js",
   "preferGlobal": true,


### PR DESCRIPTION
This allows creating several different configuration files within the same project, to allow for switching between environment configurations such as local vs qa. 

@timmfin 
